### PR TITLE
Reproduce javax.activation license problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/gradle-release/compare/release-0.9.0...master
 
+## [0.10.0] - 2024-06-14
+[0.10.0]: https://github.com/atlassian-labs/gradle-release/compare/release-0.9.0...release-0.10.0
+
 ## Added
 - Allowlist alternate spellings of Apache and BSD licenses.
 

--- a/src/test/kotlin/com/atlassian/performance/tools/license/VerifyLicensingTaskTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/license/VerifyLicensingTaskTest.kt
@@ -61,6 +61,7 @@ class VerifyLicensingTaskTest {
                 compile("io.github.bonigarcia:webdrivermanager:1.7.1")
                 implementation("com.atlassian.data:random-data:1.4.3")
                 implementation("org.apache.logging.log4j:log4j-api:2.23.1")
+                implementation("javax.activation:activation:1.1.1")
             }
             """.trimIndent()
 


### PR DESCRIPTION
It reproduces, but it's hard to fix. The https://github.com/hierynomus/license-gradle-plugin simply returns:
> `nl.javadude.gradle.plugins.license.DependencyMetadata([nl.javadude.gradle.plugins.license.LicenseMetadata(No license found, null)], javax.activation:activation:1.1.1, activation-1.1.1.jar)`

But why oh why. [The jar](https://repo1.maven.org/maven2/javax/activation/activation/1.1.1/activation-1.1.1.jar) does have the license in `META-INF/LICENSE.txt` and [the POM](https://repo1.maven.org/maven2/javax/activation/activation/1.1.1/activation-1.1.1.pom) has the license too:
```xml
<license>
  <name>
      COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
  </name>
  <url>
      https://glassfish.dev.java.net/public/CDDLv1.0.html
  </url>
</license>
```